### PR TITLE
Fix IllegalArgumentException fo UUID.fromString

### DIFF
--- a/src/main/java/tsp/headdb/database/HeadDatabase.java
+++ b/src/main/java/tsp/headdb/database/HeadDatabase.java
@@ -126,9 +126,11 @@ public class HeadDatabase {
                 JSONArray array = (JSONArray) parser.parse(response.toString());
                 for (Object o : array) {
                     JSONObject obj = (JSONObject) o;
+                    String uuid = obj.get("uuid").toString();
+                    
                     Head head = new Head(id)
                             .withName(obj.get("name").toString())
-                            .withUUID(UUID.fromString(obj.get("uuid").toString()))
+                            .withUUID(uuid.isEmpty() ? UUID.randomUUID() : UUID.fromString(uuid))
                             .withValue(obj.get("value").toString())
                             .withCategory(category);
 


### PR DESCRIPTION
It can happen that a UUID returned from the API may not be present (Is empty, which will cause this error:
```
[14:52:32 WARN]: [HeadDB] Task #527 for HeadDB v2.1 generated an exception
java.lang.IllegalArgumentException: Invalid UUID string: 
        at java.util.UUID.fromString(UUID.java:215) ~[?:?]
        at tsp.headdb.database.HeadDatabase.getHeadsNoCache(HeadDatabase.java:131) ~[?:?]
        at tsp.headdb.database.HeadDatabase.update(HeadDatabase.java:151) ~[?:?]
        at tsp.headdb.HeadDB.lambda$onEnable$1(HeadDB.java:48) ~[?:?]
        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:101) ~[patched_1.16.4.jar:git-Paper-352]
        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:468) ~[patched_1.16.4.jar:git-Paper-352]
        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:945) ~[patched_1.16.4.jar:git-Paper-352]
        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:178) ~[patched_1.16.4.jar:git-Paper-352]
        at java.lang.Thread.run(Thread.java:834) [?:?]
```

This PR should fix this, by adding a check for if the String is empty and if yes, generate a random UUID to use.

Hope this PR is fine.