### PR TITLE
Fix head names showing as 's Head

### DIFF
--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/LegacyItemFactory.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/LegacyItemFactory.java
@@ -50,6 +50,7 @@ public class LegacyItemFactory implements ItemFactory {
         String cost = String.valueOf(plugin.getCfg().getHeadOrCategoryPrice(head.getId(), head.getCategory().toLowerCase(Locale.ROOT)));
         Component name = plugin.getCfg().getHeadName().replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName())).replaceText(builder -> builder.matchLiteral("{cost}").replacement(cost));
         meta.setItemName(ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name)));
+        meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name)));
 
         List<Component> lore = new ArrayList<>(plugin.getCfg().getHeadsLore());
         lore.replaceAll(component -> component.replaceText(builder -> builder.matchLiteral("{id}").replacement(String.valueOf(head.getId())))
@@ -98,6 +99,7 @@ public class LegacyItemFactory implements ItemFactory {
     public ItemStack setItemDetails(ItemStack item, Component name, Component... lore) {
         ItemMeta meta = item.getItemMeta();
         meta.setItemName(name != null ? ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name)) : null);
+        meta.setDisplayName(name != null ? ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name)) : null);
         meta.setLore(
                 lore != null
                 ? Arrays.stream(lore).map(component -> ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(component))).toList()

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/PaperItemFactory.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/PaperItemFactory.java
@@ -4,6 +4,7 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import com.github.thesilentpro.headdb.api.model.Head;
 import com.github.thesilentpro.headdb.core.HeadDB;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -45,7 +46,9 @@ public class PaperItemFactory implements ItemFactory {
         }
 
         String cost = String.valueOf(plugin.getCfg().getHeadOrCategoryPrice(head.getId(), head.getCategory().toLowerCase(Locale.ROOT)));
-        meta.itemName(plugin.getCfg().getHeadName().replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName())).replaceText(builder -> builder.matchLiteral("{cost}").replacement(cost)));
+        Component name = plugin.getCfg().getHeadName().replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName())).replaceText(builder -> builder.matchLiteral("{cost}").replacement(cost));
+        meta.itemName(name);
+        meta.displayName(name.decoration(TextDecoration.ITALIC, false));
 
         List<Component> lore = new ArrayList<>(plugin.getCfg().getHeadsLore());
         lore.replaceAll(component -> component.replaceText(builder -> builder.matchLiteral("{id}").replacement(String.valueOf(head.getId())))
@@ -93,6 +96,7 @@ public class PaperItemFactory implements ItemFactory {
     public ItemStack setItemDetails(ItemStack item, Component name, Component... lore) {
         ItemMeta meta = item.getItemMeta();
         meta.itemName(name);
+        meta.customName(name.decoration(TextDecoration.ITALIC, false));
         meta.lore(lore != null ? Arrays.asList(lore) : null);
         item.setItemMeta(meta);
         return item;


### PR DESCRIPTION
On current minecraft versions, clients show both navigation and actual heads as `'s Head` because the name dynamically generated from the minecraft:profile takes priority over the minecraft:item_name.
see https://github.com/PaperMC/Paper/issues/13613 and https://www.minecraft.net/en-us/article/minecraft-snapshot-24w37a 
To work around this, set the higher priority displayName with italics disabled.

Since we don't have adventure apis in the LegacyItemFactory, the italics disable override was not added there. Since i don't have a legacy server install to test with, i have not confirmed this. At worst this results in italicized head names.

Tested on Purpur 1.21.11-2558

Fixes #84