### PR TITLE
feat: add Folia 1.21.11 support and fix head name rendering

### DIFF
--- a/headdb-api/pom.xml
+++ b/headdb-api/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.7-R0.1-SNAPSHOT</version>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/headdb-core/pom.xml
+++ b/headdb-core/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.7-R0.1-SNAPSHOT</version>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.22.0</version>
+            <version>4.26.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
@@ -113,17 +113,17 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>4.22.0</version>
+            <version>4.26.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-ansi</artifactId>
-            <version>4.22.0</version>
+            <version>4.26.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.22.0</version>
+            <version>4.26.1</version>
         </dependency>
     </dependencies>
 

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/HeadDB.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/HeadDB.java
@@ -77,10 +77,10 @@ public class HeadDB extends JavaPlugin {
         this.headDatabase.update().thenAcceptAsync(heads -> DATABASE_UPDATE_ACTION.accept(config, heads), Compatibility.getMainThreadExecutor(this));
         this.headApi = new BaseHeadAPI(config.getApiThreads(), headDatabase);
         this.menuManager = new MenuManager(this);
-        this.headDatabase.onReady().thenRunAsync(() -> this.menuManager.registerDefaults(this));
+        this.headDatabase.onReady().thenRunAsync(() -> this.menuManager.registerDefaults(this), Compatibility.getMainThreadExecutor(this));
         this.playerStorage = new PlayerStorage();
         this.playerStorage.load();
-        this.getServer().getScheduler().runTaskTimerAsynchronously(this, () -> this.playerStorage.save(), config.getPlayerStorageSaveInterval() * 20L, config.getPlayerStorageSaveInterval() * 20L);
+        Compatibility.runAsyncRepeating(this, this.playerStorage::save, config.getPlayerStorageSaveInterval() * 20L, config.getPlayerStorageSaveInterval() * 20L);
 
         getServer().getServicesManager().register(HeadAPI.class, headApi, this, ServicePriority.Normal);
 
@@ -102,7 +102,11 @@ public class HeadDB extends JavaPlugin {
 
         // Start updater task
         if (config.isUpdaterEnabled()) {
-            this.getServer().getScheduler().runTaskTimerAsynchronously(this, () -> this.headDatabase.update().thenAccept(heads -> DATABASE_UPDATE_ACTION.accept(config, heads)), 86400L * 20L, 86400L * 20L);
+            Compatibility.runAsyncRepeating(this, () ->
+                    this.headDatabase.update().thenAcceptAsync(heads -> DATABASE_UPDATE_ACTION.accept(config, heads), Compatibility.getMainThreadExecutor(this)),
+                    86400L * 20L,
+                    86400L * 20L
+            );
         }
 
         if (!Compatibility.IS_PAPER) {

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/Metrics.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/Metrics.java
@@ -1,5 +1,6 @@
 package com.github.thesilentpro.headdb.core;
 
+import com.github.thesilentpro.headdb.core.util.Compatibility;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -184,7 +185,11 @@ final class Metrics {
             }
             // Nevertheless we want our code to run in the Bukkit main thread, so we have to use the Bukkit scheduler
             // Don't be afraid! The connection to the bStats server is still async, only the stats collection is sync ;)
-            Bukkit.getScheduler().runTask(plugin, this::submitData);
+            if (Compatibility.IS_FOLIA) {
+                Bukkit.getGlobalRegionScheduler().execute(plugin, this::submitData);
+            } else {
+                Bukkit.getScheduler().runTask(plugin, this::submitData);
+            }
         };
 
         // Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution of requests on the

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/command/sub/HDBCommandGive.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/command/sub/HDBCommandGive.java
@@ -61,22 +61,28 @@ public class HDBCommandGive extends HDBSubCommand {
                         return plugin.getHeadApi().findByTexture(id).thenApply(optional -> optional.orElse(null));
                     }
                 })
-                .thenAcceptAsync(head -> {
+                .thenAccept(head -> {
                     if (head == null) {
-                        plugin.getLocalization().sendMessage(sender, "command.give.invalidId", msg -> msg.replaceText(builder -> builder.matchLiteral("{id}").replacement(id)));
-                        Compatibility.playSound(sender, plugin.getSoundConfig().get("failed"));
+                        Compatibility.getSenderExecutor(plugin, sender).execute(() -> {
+                            plugin.getLocalization().sendMessage(sender, "command.give.invalidId", msg -> msg.replaceText(builder -> builder.matchLiteral("{id}").replacement(id)));
+                            Compatibility.playSound(sender, plugin.getSoundConfig().get("failed"));
+                        });
                         return;
                     }
-                    ItemStack item = Compatibility.setItemDetails(head.getItem(), Component.text(head.getName()));
-                    item.setAmount(fAmount);
-                    target.getInventory().addItem(item);
-                    plugin.getLocalization().sendMessage(sender, "command.give.success", msg ->
-                            msg.replaceText(builder -> builder.matchLiteral("{amount}").replacement(String.valueOf(fAmount)))
-                            .replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName()))
-                            .replaceText(builder -> builder.matchLiteral("{target}").replacement(target.getName()))
-                    );
-                    Compatibility.playSound(sender, plugin.getSoundConfig().get("success"));
-                }, Compatibility.getMainThreadExecutor(plugin));
+                    Compatibility.getEntityExecutor(plugin, target).execute(() -> {
+                        ItemStack item = Compatibility.setItemDetails(head.getItem(), Component.text(head.getName()));
+                        item.setAmount(fAmount);
+                        target.getInventory().addItem(item);
+                        Compatibility.getSenderExecutor(plugin, sender).execute(() -> {
+                            plugin.getLocalization().sendMessage(sender, "command.give.success", msg ->
+                                    msg.replaceText(builder -> builder.matchLiteral("{amount}").replacement(String.valueOf(fAmount)))
+                                            .replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName()))
+                                            .replaceText(builder -> builder.matchLiteral("{target}").replacement(target.getName()))
+                            );
+                            Compatibility.playSound(sender, plugin.getSoundConfig().get("success"));
+                        });
+                    });
+                });
     }
 
     private static final List<String> numberCompletions = List.of("1", "32", "64");

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/command/sub/HDBCommandSearch.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/command/sub/HDBCommandSearch.java
@@ -161,7 +161,17 @@ public class HDBCommandSearch extends HDBSubCommand {
             }
 
             plugin.getLocalization().sendMessage(player, "command.search.found", msg -> msg.replaceText(builder -> builder.matchLiteral("{amount}").replacement(String.valueOf(heads.size()))).replaceText(builder -> builder.matchLiteral("{name}").replacement(searchResult.name)));
-            new HeadsGUI(plugin, "search_" + player.getUniqueId().toString(), plugin.getLocalization().getMessage(player.getUniqueId(), "menu.search.name").orElseGet(() -> Component.text("HeadDB » Search » " + searchResult.name)).replaceText(builder -> builder.matchLiteral("{name}").replacement(searchResult.name)), heads).open(player);
+
+            HeadsGUI gui = new HeadsGUI(
+                    plugin,
+                    "search_" + player.getUniqueId(),
+                    plugin.getLocalization().getMessage(player.getUniqueId(), "menu.search.name")
+                            .orElseGet(() -> Component.text("HeadDB » Search » " + searchResult.name))
+                            .replaceText(builder -> builder.matchLiteral("{name}").replacement(searchResult.name)),
+                    heads
+            );
+            gui.getGuiRegistry().setCurrentPage(player.getUniqueId(), gui.getKey(), 0);
+            gui.open(player);
             Compatibility.playSound(player, plugin.getSoundConfig().get("menu.open"));
         }, Compatibility.getEntityExecutor(plugin, player));
     }

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/command/sub/HDBCommandSearch.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/command/sub/HDBCommandSearch.java
@@ -59,7 +59,7 @@ public class HDBCommandSearch extends HDBSubCommand {
                                 try {
                                     ids.add(Integer.parseInt(trimmed));
                                 } catch (NumberFormatException e) {
-                                    sender.sendMessage("§cInvalid ID: §f" + trimmed);
+                                    Compatibility.getSenderExecutor(plugin, sender).execute(() -> sender.sendMessage("§cInvalid ID: §f" + trimmed));
                                     return null;
                                 }
                             }
@@ -73,7 +73,7 @@ public class HDBCommandSearch extends HDBSubCommand {
 
             // Echo filters to player
             String finalCategory = category;
-            Compatibility.getMainThreadExecutor(plugin).execute(() -> {
+            Compatibility.getSenderExecutor(plugin, sender).execute(() -> {
                 plugin.getLocalization().sendMessage(sender, "command.search.filter", msg -> msg.replaceText(builder ->
                                 builder.matchLiteral("{name}").replacement(!nameQuery.isEmpty() ? nameQuery : "/"))
                                 .replaceText(builder -> builder.matchLiteral("{category}").replacement(finalCategory != null ? finalCategory : "/"))
@@ -163,7 +163,7 @@ public class HDBCommandSearch extends HDBSubCommand {
             plugin.getLocalization().sendMessage(player, "command.search.found", msg -> msg.replaceText(builder -> builder.matchLiteral("{amount}").replacement(String.valueOf(heads.size()))).replaceText(builder -> builder.matchLiteral("{name}").replacement(searchResult.name)));
             new HeadsGUI(plugin, "search_" + player.getUniqueId().toString(), plugin.getLocalization().getMessage(player.getUniqueId(), "menu.search.name").orElseGet(() -> Component.text("HeadDB » Search » " + searchResult.name)).replaceText(builder -> builder.matchLiteral("{name}").replacement(searchResult.name)), heads).open(player);
             Compatibility.playSound(player, plugin.getSoundConfig().get("menu.open"));
-        }, Compatibility.getMainThreadExecutor(plugin));
+        }, Compatibility.getEntityExecutor(plugin, player));
     }
 
     @Override

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/economy/VaultEconomyProvider.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/economy/VaultEconomyProvider.java
@@ -48,7 +48,7 @@ public class VaultEconomyProvider implements EconomyProvider {
             return failed("Amount must be non-negative");
         }
 
-        return CompletableFuture.supplyAsync(() -> economy.has(player, amount));
+        return CompletableFuture.completedFuture(economy.has(player, amount));
     }
 
     @Override
@@ -61,7 +61,7 @@ public class VaultEconomyProvider implements EconomyProvider {
             return failed("Amount must be non-negative");
         }
 
-        return CompletableFuture.supplyAsync(() -> economy.withdrawPlayer(player, amount).transactionSuccess());
+        return CompletableFuture.completedFuture(economy.withdrawPlayer(player, amount).transactionSuccess());
     }
 
     @Override
@@ -74,7 +74,7 @@ public class VaultEconomyProvider implements EconomyProvider {
             return failed("Amount must be non-negative");
         }
 
-        return CompletableFuture.supplyAsync(() -> economy.depositPlayer(player, amount).transactionSuccess());
+        return CompletableFuture.completedFuture(economy.depositPlayer(player, amount).transactionSuccess());
     }
 
     private CompletableFuture<Boolean> failed(String message) {

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/LegacyItemFactory.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/LegacyItemFactory.java
@@ -49,7 +49,9 @@ public class LegacyItemFactory implements ItemFactory {
 
         String cost = String.valueOf(plugin.getCfg().getHeadOrCategoryPrice(head.getId(), head.getCategory().toLowerCase(Locale.ROOT)));
         Component name = plugin.getCfg().getHeadName().replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName())).replaceText(builder -> builder.matchLiteral("{cost}").replacement(cost));
-        meta.setItemName(ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name)));
+        String serializedName = ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name));
+        meta.setItemName(serializedName);
+        meta.setDisplayName(serializedName);
 
         List<Component> lore = new ArrayList<>(plugin.getCfg().getHeadsLore());
         lore.replaceAll(component -> component.replaceText(builder -> builder.matchLiteral("{id}").replacement(String.valueOf(head.getId())))
@@ -75,6 +77,7 @@ public class LegacyItemFactory implements ItemFactory {
 
         if (player.getName() != null) {
             meta.setItemName(player.getName());
+            meta.setDisplayName(player.getName());
         }
 
         item.setItemMeta(meta);
@@ -91,13 +94,21 @@ public class LegacyItemFactory implements ItemFactory {
     @Override
     public Component getNameFromItem(ItemStack item) {
         SkullMeta meta = (SkullMeta) item.getItemMeta();
-        return Component.text(meta.getItemName());
+        String itemName = meta.getItemName();
+        if (itemName == null || itemName.isBlank()) {
+            itemName = meta.getDisplayName();
+        }
+        return itemName != null ? LegacyComponentSerializer.legacySection().deserialize(itemName) : Component.empty();
     }
 
     @Override
     public ItemStack setItemDetails(ItemStack item, Component name, Component... lore) {
         ItemMeta meta = item.getItemMeta();
-        meta.setItemName(name != null ? ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name)) : null);
+        String serializedName = name != null
+                ? ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(name))
+                : null;
+        meta.setItemName(serializedName);
+        meta.setDisplayName(serializedName);
         meta.setLore(
                 lore != null
                 ? Arrays.stream(lore).map(component -> ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(component))).toList()

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/PaperItemFactory.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/factory/PaperItemFactory.java
@@ -4,6 +4,7 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import com.github.thesilentpro.headdb.api.model.Head;
 import com.github.thesilentpro.headdb.core.HeadDB;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -45,7 +46,11 @@ public class PaperItemFactory implements ItemFactory {
         }
 
         String cost = String.valueOf(plugin.getCfg().getHeadOrCategoryPrice(head.getId(), head.getCategory().toLowerCase(Locale.ROOT)));
-        meta.itemName(plugin.getCfg().getHeadName().replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName())).replaceText(builder -> builder.matchLiteral("{cost}").replacement(cost)));
+        Component name = plugin.getCfg().getHeadName()
+                .replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName()))
+                .replaceText(builder -> builder.matchLiteral("{cost}").replacement(cost));
+        meta.itemName(name);
+        meta.displayName(name.decoration(TextDecoration.ITALIC, false));
 
         List<Component> lore = new ArrayList<>(plugin.getCfg().getHeadsLore());
         lore.replaceAll(component -> component.replaceText(builder -> builder.matchLiteral("{id}").replacement(String.valueOf(head.getId())))
@@ -71,7 +76,9 @@ public class PaperItemFactory implements ItemFactory {
         SkullMeta meta = (SkullMeta) item.getItemMeta();
         PlayerProfile profile = Bukkit.createProfile(player.getUniqueId(), player.getName());
         meta.setPlayerProfile(profile);
-        meta.itemName(Component.text(player.getName()));
+        Component name = Component.text(player.getName());
+        meta.itemName(name);
+        meta.displayName(name.decoration(TextDecoration.ITALIC, false));
         item.setItemMeta(meta);
         return item;
     }
@@ -86,13 +93,19 @@ public class PaperItemFactory implements ItemFactory {
     @Override
     public Component getNameFromItem(ItemStack item) {
         SkullMeta meta = (SkullMeta) item.getItemMeta();
-        return meta.itemName();
+        Component itemName = meta.itemName();
+        if (itemName != null) {
+            return itemName;
+        }
+        Component displayName = meta.displayName();
+        return displayName != null ? displayName : Component.empty();
     }
 
     @Override
     public ItemStack setItemDetails(ItemStack item, Component name, Component... lore) {
         ItemMeta meta = item.getItemMeta();
         meta.itemName(name);
+        meta.displayName(name != null ? name.decoration(TextDecoration.ITALIC, false) : null);
         meta.lore(lore != null ? Arrays.asList(lore) : null);
         item.setItemMeta(meta);
         return item;

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/menu/MainMenu.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/menu/MainMenu.java
@@ -34,7 +34,7 @@ public class MainMenu extends SimplePage {
         super(plugin.getLocalization().getConsoleMessage("menu.main.name").orElse(Component.text("HeadDB").color(NamedTextColor.RED)), 6);
         preventInteraction();
 
-        plugin.getHeadApi().onReady().thenAccept(heads -> {
+        plugin.getHeadApi().onReady().thenAcceptAsync(heads -> {
             LOGGER.debug("RENDER THREAD = {}", Thread.currentThread().getName());
             renderCategoryButtons(plugin, heads);
             renderLocalButton(plugin);
@@ -44,7 +44,7 @@ public class MainMenu extends SimplePage {
             renderInfoButton(plugin);
             fillBorder(this);
             reRender();
-        });
+        }, Compatibility.getMainThreadExecutor(plugin));
     }
 
     private void renderCategoryButtons(HeadDB plugin, List<Head> heads) {
@@ -157,7 +157,7 @@ public class MainMenu extends SimplePage {
                         int page = plugin.getCfg().isTrackPage() ? gui.getGuiRegistry().getCurrentPage(playerId, gui.getKey()).orElse(0) : 0;
                         gui.open(player, page);
                         Compatibility.playSound(player, plugin.getSoundConfig().get("menu.open"));
-                    }, Compatibility.getMainThreadExecutor(plugin))
+                    }, Compatibility.getEntityExecutor(plugin, player))
                     .exceptionally(ex -> {
                         LOGGER.error("Failed to compute favorite heads for: {}", playerId, ex);
                         return null;
@@ -213,7 +213,7 @@ public class MainMenu extends SimplePage {
             Compatibility.playSound(player, plugin.getSoundConfig().get("input.wait"));
             PaperInput.awaitString().then((input, event) -> {
                 event.setCancelled(true);
-                Compatibility.getMainThreadExecutor(plugin).execute(() -> player.performCommand("hdb search " + input));
+                Compatibility.getEntityExecutor(plugin, player).execute(() -> player.performCommand("hdb search " + input));
             }).register(player.getUniqueId());
         }));
     }

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/menu/PurchaseHeadMenu.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/menu/PurchaseHeadMenu.java
@@ -61,9 +61,9 @@ public class PurchaseHeadMenu extends SimplePage {
             PaperInput.awaitInteger()
                     .mismatch((input, event) -> {
                         event.setCancelled(true);
-                        Compatibility.getMainThreadExecutor(plugin).execute(() -> {
+                        Compatibility.getEntityExecutor(plugin, entity).execute(() -> {
                             plugin.getLocalization().sendMessage(event.getPlayer(), "invalidNumber", msg -> msg.replaceText(builder -> builder.matchLiteral("{number}").replacement(input)));
-                            Compatibility.playSound((Player) ctx.event().getWhoClicked(), plugin.getSoundConfig().get("purchase.failed"));
+                            Compatibility.playSound(entity, plugin.getSoundConfig().get("purchase.failed"));
                         });
                     })
                     .then((input, event) -> {
@@ -84,23 +84,24 @@ public class PurchaseHeadMenu extends SimplePage {
     private Consumer<ButtonClickContext> handlePurchase(double cost, int amount) {
         return ctx -> {
             double price = cost * amount;
-            plugin.getEconomyProvider().purchase((Player) ctx.event().getWhoClicked(), price).thenAcceptAsync(success -> {
+            Player player = (Player) ctx.event().getWhoClicked();
+            plugin.getEconomyProvider().purchase(player, price).thenAcceptAsync(success -> {
                 if (!success) {
-                    plugin.getLocalization().sendMessage(ctx.event().getWhoClicked(), "purchase.invalidFunds");
-                    Compatibility.playSound((Player) ctx.event().getWhoClicked(), plugin.getSoundConfig().get("purchase.failed"));
+                    plugin.getLocalization().sendMessage(player, "purchase.invalidFunds");
+                    Compatibility.playSound(player, plugin.getSoundConfig().get("purchase.failed"));
                     return;
                 }
 
                 ItemStack item = head.getItem();
                 item.setAmount(amount);
-                ItemFactoryRegistry.get().giveItem((Player) ctx.event().getWhoClicked(), plugin.getCfg().getOmit(), item);
-                plugin.getLocalization().sendMessage(ctx.event().getWhoClicked(), "purchase.success", msg ->
+                ItemFactoryRegistry.get().giveItem(player, plugin.getCfg().getOmit(), item);
+                plugin.getLocalization().sendMessage(player, "purchase.success", msg ->
                         msg.replaceText(builder -> builder.matchLiteral("{amount}").replacement(String.valueOf(amount)))
                                 .replaceText(builder -> builder.matchLiteral("{name}").replacement(head.getName()))
                                 .replaceText(builder -> builder.matchLiteral("{cost}").replacement(String.valueOf(price)))
                 );
-                Compatibility.playSound((Player) ctx.event().getWhoClicked(), plugin.getSoundConfig().get("purchase.completed"));
-            }, Compatibility.getMainThreadExecutor(plugin));
+                Compatibility.playSound(player, plugin.getSoundConfig().get("purchase.completed"));
+            }, Compatibility.getEntityExecutor(plugin, player));
         };
     }
 

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/storage/PlayerData.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/storage/PlayerData.java
@@ -1,7 +1,9 @@
 package com.github.thesilentpro.headdb.core.storage;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class PlayerData {
 
@@ -15,8 +17,8 @@ public class PlayerData {
         this.uniqueId = uniqueId;
         this.language = language;
         this.soundEnabled = soundEnabled;
-        this.favorites = favorites;
-        this.localFavorites = localFavorites;
+        this.favorites = new CopyOnWriteArrayList<>(favorites != null ? favorites : new ArrayList<>());
+        this.localFavorites = new CopyOnWriteArrayList<>(localFavorites != null ? localFavorites : new ArrayList<>());
     }
 
     public void addLocalFavorite(UUID uuid) {
@@ -32,7 +34,7 @@ public class PlayerData {
     }
 
     public void setLocalFavorites(List<UUID> localFavorites) {
-        this.localFavorites = localFavorites;
+        this.localFavorites = new CopyOnWriteArrayList<>(localFavorites != null ? localFavorites : new ArrayList<>());
     }
 
     public void setLanguage(String language) {
@@ -48,7 +50,7 @@ public class PlayerData {
     }
 
     public void setFavorites(List<Integer> favorites) {
-        this.favorites = favorites;
+        this.favorites = new CopyOnWriteArrayList<>(favorites != null ? favorites : new ArrayList<>());
     }
 
     public void setSoundEnabled(boolean soundEnabled) {

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/storage/PlayerStorage.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/storage/PlayerStorage.java
@@ -8,16 +8,16 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PlayerStorage {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PlayerStorage.class);
     private static final String DB_URL = "jdbc:sqlite:plugins/HeadDB/data/data.db";
 
-    private final Map<UUID, PlayerData> data = new HashMap<>();
+    private final Map<UUID, PlayerData> data = new ConcurrentHashMap<>();
 
     private final PlayerDAO playerDao;
 

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/util/Compatibility.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/util/Compatibility.java
@@ -7,6 +7,7 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -14,32 +15,104 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("deprecation")
 public class Compatibility {
 
     public static final boolean IS_PAPER;
+    public static final boolean IS_FOLIA;
 
     static {
         boolean isPaper;
+        boolean isFolia;
         try {
             Class.forName("com.destroystokyo.paper.profile.PlayerProfile");
             isPaper = true;
         } catch (ClassNotFoundException e) {
             isPaper = false;
         }
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            isFolia = true;
+        } catch (ClassNotFoundException e) {
+            isFolia = false;
+        }
         IS_PAPER = isPaper;
+        IS_FOLIA = isFolia;
     }
 
     public static Executor getMainThreadExecutor(JavaPlugin plugin) {
         if (plugin == null) {
             throw new RuntimeException("Plugin instance is null!");
         }
-        if (IS_PAPER) {
+        if (IS_FOLIA) {
+            return r -> plugin.getServer().getGlobalRegionScheduler().execute(plugin, r);
+        } else if (IS_PAPER) {
             return plugin.getServer().getScheduler().getMainThreadExecutor(plugin);
         } else {
             return r -> plugin.getServer().getScheduler().runTask(plugin, r);
         }
+    }
+
+    public static Executor getEntityExecutor(JavaPlugin plugin, Entity entity) {
+        if (plugin == null) {
+            throw new RuntimeException("Plugin instance is null!");
+        }
+        if (entity == null) {
+            throw new RuntimeException("Entity instance is null!");
+        }
+
+        if (!IS_FOLIA) {
+            return getMainThreadExecutor(plugin);
+        }
+
+        return r -> {
+            if (!entity.isValid()) {
+                return;
+            }
+            if (entity instanceof Player player && !player.isOnline()) {
+                return;
+            }
+
+            entity.getScheduler().execute(plugin, r, () -> { }, 1L);
+        };
+    }
+
+    public static Executor getSenderExecutor(JavaPlugin plugin, CommandSender sender) {
+        if (sender instanceof Entity entity) {
+            return getEntityExecutor(plugin, entity);
+        }
+        return getMainThreadExecutor(plugin);
+    }
+
+    public static void runAsyncRepeating(JavaPlugin plugin, Runnable task, long initialDelayTicks, long periodTicks) {
+        if (plugin == null) {
+            throw new RuntimeException("Plugin instance is null!");
+        }
+        if (task == null) {
+            return;
+        }
+
+        if (IS_FOLIA) {
+            plugin.getServer().getAsyncScheduler().runAtFixedRate(
+                    plugin,
+                    scheduledTask -> task.run(),
+                    ticksToMillis(initialDelayTicks),
+                    ticksToMillis(periodTicks),
+                    TimeUnit.MILLISECONDS
+            );
+            return;
+        }
+
+        plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, task, initialDelayTicks, periodTicks);
+    }
+
+    private static long ticksToMillis(long ticks) {
+        if (ticks <= 0L) {
+            return 0L;
+        }
+        return ticks * 50L;
     }
 
     public static String getPluginVersion(JavaPlugin plugin) {

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/util/HDBLocalization.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/core/util/HDBLocalization.java
@@ -35,7 +35,7 @@ public class HDBLocalization extends PaperLocalization {
             if ((textMessage.content().isEmpty() || textMessage.content().isBlank()) && textMessage.children().isEmpty()) {
                 return;
             }
-            Compatibility.sendMessage(entity, message);
+            Compatibility.getEntityExecutor(plugin, entity).execute(() -> Compatibility.sendMessage(entity, message));
         }
     }
 

--- a/headdb-core/src/main/java/com/github/thesilentpro/headdb/implementation/model/BaseHead.java
+++ b/headdb-core/src/main/java/com/github/thesilentpro/headdb/implementation/model/BaseHead.java
@@ -13,7 +13,7 @@ public class BaseHead implements Head {
     private final String texture;
     private final String category;
     private final List<String> tags;
-    private ItemStack item;
+    private volatile ItemStack item;
 
     public BaseHead(int id, String name, String texture, String category, List<String> tags) {
         this.id = id;
@@ -25,10 +25,17 @@ public class BaseHead implements Head {
 
     @Override
     public ItemStack getItem() {
-        if (this.item == null) {
-            this.item = ItemFactoryRegistry.get().asItem(this);
+        ItemStack cached = this.item;
+        if (cached == null) {
+            synchronized (this) {
+                cached = this.item;
+                if (cached == null) {
+                    cached = ItemFactoryRegistry.get().asItem(this);
+                    this.item = cached;
+                }
+            }
         }
-        return this.item.clone(); // Returns a clone of the original to avoid modifying it.
+        return cached.clone(); // Returns a clone of the original to avoid modifying it.
     }
 
     @Override

--- a/headdb-core/src/main/resources/plugin.yml
+++ b/headdb-core/src/main/resources/plugin.yml
@@ -8,7 +8,8 @@ softdepend: [
   #"PlaceholderAPI",
   "Vault"
 ]
-api-version: 1.19
+api-version: 1.21
+folia-supported: true
 libraries:
   - "org.xerial:sqlite-jdbc:3.47.0.0"
 


### PR DESCRIPTION
Summary:
- migrate scheduling/executor usage to Folia-safe global/entity sender dispatch
- mark plugin as Folia supported and update Paper API targets to 1.21.11
- align Adventure deps for compatibility with current GUI/input libraries
- harden shared state for concurrent region-thread access

Description:
- added Compatibility helpers for Folia global/entity execution and async repeating tasks
- replaced direct Bukkit async timers and main-thread assumptions in startup, menus, commands, localization, and metrics submit flow
- updated Vault economy calls to run on caller thread and return completed futures to avoid unsafe async player access
- fixed head display names showing as "'s Head" by setting both itemName and displayName in Paper/Legacy item factories and by improving name fallback reads
- added thread-safe caching for head ItemStack creation and concurrent-safe player storage collections